### PR TITLE
gitconfig: improve rbm alias base detection

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -31,7 +31,7 @@
 	rba = rebase --abort
 	rbc = rebase --continue
 	rbi = rebase -i
-	rbm = "!fn(){ branch=''; if git show-ref --verify --quiet refs/heads/master; then branch='master'; elif git show-ref --verify --quiet refs/heads/main; then branch='main'; fi; if [ -n '$branch' ]; then git rebase $branch $1; else echo 'Both master and main branch not found!' >&2; return 1; fi; };fn"
+	rbm = "!fn(){ base=''; remote_head=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true); remote_branch=${remote_head#origin/}; if [ -n \"$remote_branch\" ] && [ \"$remote_branch\" != \"$remote_head\" ]; then case \"$remote_branch\" in master|main) if git show-ref --verify --quiet \"refs/heads/$remote_branch\"; then base=$remote_branch; elif git show-ref --verify --quiet \"refs/remotes/origin/$remote_branch\"; then base=origin/$remote_branch; fi;; esac; fi; if [ -z \"$base\" ] && git show-ref --verify --quiet refs/heads/master; then base=master; elif [ -z \"$base\" ] && git show-ref --verify --quiet refs/heads/main; then base=main; fi; if [ -z \"$base\" ] && [ -n \"$remote_branch\" ]; then if git show-ref --verify --quiet \"refs/heads/$remote_branch\"; then base=$remote_branch; elif [ -n \"$remote_head\" ] && git show-ref --verify --quiet \"refs/remotes/$remote_head\"; then base=$remote_head; fi; fi; if [ -z \"$base\" ]; then echo 'Both master and main branch not found!' >&2; return 1; fi; git rebase \"$base\" \"$@\"; };fn"
 	rmt = remote
 	rmtv = remote -v
 	rmta = remote add


### PR DESCRIPTION
### **User description**
Let `rbm` resolve master/main from local refs first, then fall back to the remote default branch chosen via origin/HEAD (including remote-only refs). Forward all user-supplied arguments to git rebase so the alias mirrors the native command’s behavior.

GitHub Copilot Summary:

> This pull request updates the `rbm` git alias in the `gitconfig` file to make it more robust and flexible when rebasing onto the main development branch. The new alias now better detects whether the main branch is named `master` or `main`, and also supports rebasing onto the corresponding remote branch if the local branch doesn't exist.
> 
> **Improvements to git alias functionality:**
> 
> * Updated the `rbm` alias to dynamically detect the default branch (`master` or `main`) both locally and on the remote, and to fall back to the appropriate remote branch if needed. This makes the alias more reliable in repositories that use different naming conventions for the main branch.


___

### **PR Type**
Enhancement


___

### **Description**
- Improved `rbm` alias to detect default branch from `origin/HEAD` first

- Falls back to local `master`/`main` branches if remote default unavailable

- Supports remote-only branches when local equivalents don't exist

- Forwards all user arguments to `git rebase` command


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["origin/HEAD<br/>symbolic ref"] -->|Extract remote branch| B["Check if master/main"]
  B -->|Found locally| C["Use local branch"]
  B -->|Not found locally| D["Use remote branch"]
  D -->|Still not found| E["Fallback to<br/>master/main"]
  E -->|Not found| F["Error"]
  C --> G["git rebase<br/>with all args"]
  D --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitconfig</strong><dd><code>Improve rbm alias branch detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gitconfig

<ul><li>Enhanced <code>rbm</code> alias to resolve default branch from <code>origin/HEAD</code> symbolic <br>reference first<br> <li> Added fallback logic to check local <code>master</code>/<code>main</code> branches if remote <br>default unavailable<br> <li> Implemented support for remote-only branches when local equivalents <br>don't exist<br> <li> Changed argument passing from single positional argument to all <br>user-supplied arguments via <code>"$@"</code></ul>


</details>


  </td>
  <td><a href="https://github.com/PeterDaveHello/Unitial/pull/5/files#diff-3f65771ff5ae4cb79982edadedc77b8c27952b7c5877241b83f7531f7edb4b17">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the `rbm` Git alias for improved base branch detection. Now intelligently derives the base branch from remote origin HEAD with fallback logic to master or main branches, providing more robust handling of edge cases and remote branch naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->